### PR TITLE
Change default start delay to zero

### DIFF
--- a/configs/config.json
+++ b/configs/config.json
@@ -19,6 +19,6 @@
 	},
 	"Verbose": true,
 	"MinUserID": 1000,
-	"StartDelay": 20,
+	"StartDelay": 0,
 	"Notifications": true
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,7 +135,7 @@ func Default() *Config {
 		LogoutTimeout: 5,
 		RetryTimer:    15,
 		MinUserID:     1000,
-		StartDelay:    20,
+		StartDelay:    0,
 		Notifications: true,
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -106,7 +106,7 @@ func TestDefault(t *testing.T) {
 		LogoutTimeout: 5,
 		RetryTimer:    15,
 		MinUserID:     1000,
-		StartDelay:    20,
+		StartDelay:    0,
 		Notifications: true,
 	}
 	got := Default()
@@ -178,7 +178,7 @@ func TestLoad(t *testing.T) {
         },
 	"Verbose": true,
 	"MinUserID": 1000,
-	"StartDelay": 20,
+	"StartDelay": 0,
 	"Notifications": true
 }`,
 		`{
@@ -238,7 +238,7 @@ func TestLoad(t *testing.T) {
 			},
 			Verbose:       true,
 			MinUserID:     1000,
-			StartDelay:    20,
+			StartDelay:    0,
 			Notifications: true,
 		}
 		if !reflect.DeepEqual(want, cfg) {


### PR DESCRIPTION
Initially, we set a fixed start delay of 20 seconds to avoid missing desktop notifications during login when the notifications service is not ready yet. Now, we have tools to check the current agent status, users can change the start delay in the config file and on the command line, and users can disable desktop notifications completely. So, it is OK to disable the start delay by default by setting it to 0.