### PR TITLE
Do not start systemd service as system user

### DIFF
--- a/init/fw-id-agent.service
+++ b/init/fw-id-agent.service
@@ -2,6 +2,7 @@
 Description=Firewall Identity Agent
 Requires=dbus.service
 After=dbus.service
+ConditionUser=!@system
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Start the FW-ID-Agent systemd service only as regular user.