### PR TITLE
Remove minimum allowed user ID

### DIFF
--- a/configs/config.json
+++ b/configs/config.json
@@ -24,7 +24,6 @@
 		}
 	},
 	"Verbose": true,
-	"MinUserID": 1000,
 	"StartDelay": 0,
 	"Notifications": true
 }

--- a/internal/agent/cmd_test.go
+++ b/internal/agent/cmd_test.go
@@ -1,12 +1,9 @@
 package agent
 
 import (
-	"errors"
 	"flag"
 	"fmt"
-	"math"
 	"os"
-	"os/user"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -144,7 +141,6 @@ func TestGetConfig(t *testing.T) {
 			fmt.Sprintf("--%s=1", argRetryTimer),
 			fmt.Sprintf("--%s=example:abcdef", argTNDServers),
 			fmt.Sprintf("--%s=false", argVerbose),
-			fmt.Sprintf("--%s=1000", argMinUserID),
 			fmt.Sprintf("--%s=0", argStartDelay),
 			fmt.Sprintf("--%s=false", argNotifications),
 		}
@@ -171,52 +167,4 @@ func TestSetVerbose(t *testing.T) {
 	if log.GetLevel() != log.DebugLevel {
 		t.Error("log level should be debug")
 	}
-}
-
-// TestCheckUser tests checkUser.
-func TestCheckUser(t *testing.T) {
-	// test invalid user, error getting user ID
-	t.Run("error getting user", func(t *testing.T) {
-		defer func() { userCurrent = user.Current }()
-		userCurrent = func() (*user.User, error) {
-			return nil, errors.New("test error")
-		}
-
-		cfg := config.Default()
-		if err := checkUser(cfg); err == nil {
-			t.Error("should be unable to get user ID")
-		}
-	})
-
-	// test invalid user, user ID invalid
-	t.Run("invalid user ID", func(t *testing.T) {
-		defer func() { userCurrent = user.Current }()
-		userCurrent = func() (*user.User, error) {
-			return &user.User{Uid: "invalid"}, nil
-		}
-
-		cfg := config.Default()
-		if err := checkUser(cfg); err == nil {
-			t.Error("should be unable to convert invalid user ID")
-		}
-	})
-
-	// test invalid user, user ID too low
-	t.Run("low user ID", func(t *testing.T) {
-		cfg := config.Default()
-		cfg.MinUserID = math.MaxUint32
-		if err := checkUser(cfg); err == nil {
-			t.Error("user ID should be invalid")
-		}
-	})
-
-	// test valid user
-	t.Run("valid", func(t *testing.T) {
-		cfg := config.Default()
-		cfg.MinUserID = 0
-
-		if err := checkUser(cfg); err != nil {
-			t.Errorf("user should be valid: %v", err)
-		}
-	})
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,8 +73,6 @@ type Config struct {
 	TND TNDConfig
 	// Verbose specifies whether the client should show verbose output.
 	Verbose bool
-	// MinUserID is the minimum allowed user ID.
-	MinUserID int
 	// StartDelay is the time the agent sleeps before starting in seconds.
 	StartDelay int
 	// Notifications specifies whether the agent should show desktop notifications.
@@ -126,7 +124,6 @@ func (c *Config) Valid() bool {
 		c.LogoutTimeout < 0 ||
 		c.RetryTimer < 0 ||
 		!c.TND.Valid() ||
-		c.MinUserID < 0 ||
 		c.StartDelay < 0 {
 		return false
 	}
@@ -146,7 +143,6 @@ func Default() *Config {
 		LogoutTimeout: 5,
 		RetryTimer:    15,
 		TND:           TNDConfig{Config: tnd.NewConfig()},
-		MinUserID:     1000,
 		StartDelay:    0,
 		Notifications: true,
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -131,7 +131,6 @@ func TestDefault(t *testing.T) {
 		LogoutTimeout: 5,
 		RetryTimer:    15,
 		TND:           TNDConfig{Config: tnd.NewConfig()},
-		MinUserID:     1000,
 		StartDelay:    0,
 		Notifications: true,
 	}
@@ -215,7 +214,6 @@ func TestLoad(t *testing.T) {
 		}
         },
 	"Verbose": true,
-	"MinUserID": 1000,
 	"StartDelay": 0,
 	"Notifications": true
 }`,
@@ -277,7 +275,6 @@ func TestLoad(t *testing.T) {
 				tnd.NewConfig(),
 			},
 			Verbose:       true,
-			MinUserID:     1000,
 			StartDelay:    0,
 			Notifications: true,
 		}


### PR DESCRIPTION
In order to avoid running as system user - especially the display manager user - when enabling the systemd user service for all users, FW-ID-Agent only starts if the current user's ID is higher than a configured minimum allowed user ID (default: 1000). The latest systemd service file in init/fw-id-agent.service already contains such a check. So, remove this check from the code and remove the minimum allowed user ID from the config.