### PR TITLE
Update GoReleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,6 @@ builds:
       - -s -w -X github.com/telekom-mms/fw-id-agent/internal/agent.Version={{.Version}}-{{.Commit}}
 archives:
   - format: tar.gz
-    rlcp: true
     wrap_in_directory: true
     files:
       - src: init/fw-id-agent.service
@@ -90,7 +89,7 @@ nfpms:
         file_info:
           mode: 0644
       - src: configs/config.json
-        dst: /usr/share/fw-id-agent/
+        dst: /usr/share/doc/fw-id-agent/examples/
         file_info:
           mode: 0644
       - src: copyright

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Download the package from releases page and use the following instructions to in
 
 ```console
 $ sudo apt install ./fw-id-agent.deb
-$ sudo cp /usr/share/fw-id-agent/config.json /etc/fw-id-agent.json # and adjust config parameters
+$ sudo cp /usr/share/doc/fw-id-agent/examples/config.json /etc/fw-id-agent.json # and adjust config parameters
 $ sudo systemctl --user start fw-id-agent.service
 ```
 


### PR DESCRIPTION
- Remove deprecated rlcp option
- Change path of example config in .deb
- Update installation instructions