### PR TITLE
Fix linter warnings

### DIFF
--- a/internal/agent/sleepmon_test.go
+++ b/internal/agent/sleepmon_test.go
@@ -72,7 +72,7 @@ func TestSleepMonStartSignalsChan(t *testing.T) {
 func TestSleepMonStartError(t *testing.T) {
 	// match signal error
 	oldAddMatchSignal := connAddMatchSignal
-	connAddMatchSignal = func(conn *dbus.Conn, options ...dbus.MatchOption) error {
+	connAddMatchSignal = func(*dbus.Conn, ...dbus.MatchOption) error {
 		return errors.New("test error")
 	}
 	defer func() { connAddMatchSignal = oldAddMatchSignal }()
@@ -83,7 +83,7 @@ func TestSleepMonStartError(t *testing.T) {
 	}
 
 	// systembus error
-	dbusConnectSystemBus = func(ops ...dbus.ConnOption) (*dbus.Conn, error) {
+	dbusConnectSystemBus = func(...dbus.ConnOption) (*dbus.Conn, error) {
 		return nil, errors.New("test error")
 	}
 	defer func() { dbusConnectSystemBus = dbus.ConnectSystemBus }()

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -21,7 +21,7 @@ import (
 
 // initTestServer initializes a test server.
 func initTestServer(expected string) *httptest.Server {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte(expected))
@@ -91,7 +91,7 @@ func TestClientDoServiceRequestErrors(t *testing.T) {
 
 	t.Run("error response", func(t *testing.T) {
 		old := clientDo
-		clientDo = func(client *spnego.Client, request *http.Request) (*http.Response, error) {
+		clientDo = func(*spnego.Client, *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 300,
 				Body:       io.NopCloser(iotest.ErrReader(errors.New("test error"))),
@@ -204,7 +204,7 @@ func TestClientLoginFailed(t *testing.T) {
 		{StatusCode: 404, Body: io.NopCloser(&bytes.Buffer{})},
 		{StatusCode: 200, Body: io.NopCloser(iotest.ErrReader(errors.New("test error")))},
 	} {
-		clientDo = func(client *spnego.Client, request *http.Request) (*http.Response, error) {
+		clientDo = func(*spnego.Client, *http.Request) (*http.Response, error) {
 
 			return response, nil
 		}
@@ -280,7 +280,7 @@ func TestClientLogout(t *testing.T) {
 func TestClientStartStop(t *testing.T) {
 	t.Run("failed login", func(t *testing.T) {
 		// create server
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(404)
 		}))
 		defer server.Close()

--- a/internal/dbusapi/service_test.go
+++ b/internal/dbusapi/service_test.go
@@ -128,10 +128,10 @@ func (tp *testProperties) SetMust(_, property string, v any) {
 
 // TestServiceStartStop tests Start and Stop of Service.
 func TestServiceStartStop(t *testing.T) {
-	dbusConnectSessionBus = func(opts ...dbus.ConnOption) (dbusConn, error) {
+	dbusConnectSessionBus = func(...dbus.ConnOption) (dbusConn, error) {
 		return &testConn{}, nil
 	}
-	propExport = func(conn dbusConn, path dbus.ObjectPath, props prop.Map) (propProperties, error) {
+	propExport = func(dbusConn, dbus.ObjectPath, prop.Map) (propProperties, error) {
 		return &testProperties{}, nil
 	}
 	s := NewService()
@@ -153,11 +153,11 @@ func TestServiceRequests(t *testing.T) {
 
 // TestServiceSetProperty tests SetProperty of Service.
 func TestServiceSetProperty(t *testing.T) {
-	dbusConnectSessionBus = func(opts ...dbus.ConnOption) (dbusConn, error) {
+	dbusConnectSessionBus = func(...dbus.ConnOption) (dbusConn, error) {
 		return &testConn{}, nil
 	}
 	properties := &testProperties{props: make(map[string]any)}
-	propExport = func(conn dbusConn, path dbus.ObjectPath, props prop.Map) (propProperties, error) {
+	propExport = func(dbusConn, dbus.ObjectPath, prop.Map) (propProperties, error) {
 		return properties, nil
 	}
 	s := NewService()

--- a/internal/krbmon/ccachemon_test.go
+++ b/internal/krbmon/ccachemon_test.go
@@ -233,7 +233,7 @@ func TestCCacheMonStartStop(t *testing.T) {
 	t.Run("start with errors", func(t *testing.T) {
 		// test with Watcher.Add() error
 		oldWatcherAdd := watcherAdd
-		watcherAdd = func(watcher *fsnotify.Watcher, name string) error {
+		watcherAdd = func(*fsnotify.Watcher, string) error {
 			return errors.New("test error")
 		}
 		defer func() { watcherAdd = oldWatcherAdd }()

--- a/internal/krbmon/confmon_test.go
+++ b/internal/krbmon/confmon_test.go
@@ -148,7 +148,7 @@ func TestConfMonStartStop(t *testing.T) {
 	t.Run("start with errors", func(t *testing.T) {
 		// test with Watcher.Add() error
 		oldWatcherAdd := watcherAdd
-		watcherAdd = func(watcher *fsnotify.Watcher, name string) error {
+		watcherAdd = func(*fsnotify.Watcher, string) error {
 			return errors.New("test error")
 		}
 		defer func() { watcherAdd = oldWatcherAdd }()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -199,7 +199,7 @@ func TestDBusClientSubscribe(t *testing.T) {
 	dbusConnectSessionBus = func(...dbus.ConnOption) (*dbus.Conn, error) {
 		return nil, nil
 	}
-	dbusConnSignal = func(conn *dbus.Conn, ch chan<- *dbus.Signal) {
+	dbusConnSignal = func(_ *dbus.Conn, ch chan<- *dbus.Signal) {
 		close(ch)
 	}
 
@@ -221,7 +221,7 @@ func TestDBusClientSubscribe(t *testing.T) {
 	}
 
 	// set match signal error
-	dbusConnAddMatchSignal = func(conn *dbus.Conn, options ...dbus.MatchOption) error {
+	dbusConnAddMatchSignal = func(*dbus.Conn, ...dbus.MatchOption) error {
 		return errors.New("test error")
 	}
 
@@ -233,7 +233,7 @@ func TestDBusClientSubscribe(t *testing.T) {
 	}
 
 	// set match signal OK
-	dbusConnAddMatchSignal = func(conn *dbus.Conn, options ...dbus.MatchOption) error {
+	dbusConnAddMatchSignal = func(*dbus.Conn, ...dbus.MatchOption) error {
 		return nil
 	}
 
@@ -277,7 +277,7 @@ func TestDBusClientSubscribe(t *testing.T) {
 			}, []string{}},
 		},
 	}
-	dbusConnSignal = func(conn *dbus.Conn, ch chan<- *dbus.Signal) {
+	dbusConnSignal = func(_ *dbus.Conn, ch chan<- *dbus.Signal) {
 		go func() {
 			for _, s := range signals {
 				ch <- s
@@ -317,7 +317,7 @@ func TestDBusClientReLogin(t *testing.T) {
 
 	// test with no error
 	client := &DBusClient{}
-	relogin = func(d *DBusClient) error {
+	relogin = func(*DBusClient) error {
 		return nil
 	}
 	err := client.ReLogin()
@@ -327,7 +327,7 @@ func TestDBusClientReLogin(t *testing.T) {
 
 	// test with error
 	client = &DBusClient{}
-	relogin = func(d *DBusClient) error {
+	relogin = func(*DBusClient) error {
 		return errors.New("test error")
 	}
 	err = client.ReLogin()


### PR DESCRIPTION
Fix unused parameter warnings of the revive linter in tests by removing unused parameter variables or replacing them with `_`.