### PR TITLE
Improve logging of Agent config on startup in verbose mode

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,6 +135,12 @@ func (c *Config) JSON() ([]byte, error) {
 	return json.Marshal(c)
 }
 
+// String returns Config as string.
+func (c *Config) String() string {
+	b, _ := c.JSON()
+	return string(b)
+}
+
 // Default returns a new config with default values.
 func Default() *Config {
 	return &Config{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -123,6 +123,22 @@ func TestConfigValid(t *testing.T) {
 	}
 }
 
+// TestConfigString tests String of Config.
+func TestConfigString(t *testing.T) {
+	// default config
+	c := Default()
+	if c.String() == "" {
+		t.Errorf("string should not be empty: %s", c.String())
+	}
+
+	// nil
+	c = nil
+	if c.String() != "null" {
+		t.Errorf("string should be null: %s", c.String())
+	}
+
+}
+
 // TestDefault tests Default.
 func TestDefault(t *testing.T) {
 	want := &Config{


### PR DESCRIPTION
Add String() method to Config to improve logging of the Agent config on startup in verbose mode.